### PR TITLE
fixed new erosion criterion

### DIFF
--- a/seat/shear_stress_module.py
+++ b/seat/shear_stress_module.py
@@ -93,7 +93,7 @@ def classify_mobility(mobility_parameter_dev, mobility_parameter_nodev):
 
     mobility_classification = np.zeros(mobility_parameter_dev.shape)
     # New Erosion
-    mobility_classification = np.where(((mobility_parameter_dev < mobility_parameter_nodev) & (
+    mobility_classification = np.where(((mobility_parameter_nodev < mobility_parameter_dev) & (
         mobility_parameter_nodev < 1) & (mobility_parameter_dev >= 1)), 3, mobility_classification)
     # Reduced Erosion (Tw<Tb) & (Tw-Tb)>1
     mobility_classification = np.where(((mobility_parameter_dev < mobility_parameter_nodev) & (


### PR DESCRIPTION
changed 
 mobility_classification = np.where(((mobility_parameter_dev < mobility_parameter_nodev) & ( 
     mobility_parameter_nodev < 1) & (mobility_parameter_dev >= 1)), 3, mobility_classification)
to 
    mobility_classification = np.where(((mobility_parameter_nodev < mobility_parameter_dev) & (
        mobility_parameter_nodev < 1) & (mobility_parameter_dev >= 1)), 3, mobility_classification)